### PR TITLE
Add Claude settings configuration file

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch",
+      "WebSearch"
+    ]
+  },
+  "sandbox": {
+    "autoAllowBashIfSandboxed": true,
+    "enabled": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ ninja # builds figures and the paper
 git commit # checks format, lints, and type checks
 ```
 
+### Claude Code
+
+Default project settings in `.claude/settings.json` allow all bash commands sandboxed to the working directory and all network requests (`WebFetch`, `WebSearch`). This is a good balance between security and velocity. Override these in `.claude/settings.local.json` if you like.
+
 ### Files to know
 
 - `flake.nix` defines system dependencies like `texlive`


### PR DESCRIPTION
## Summary
This PR introduces a new `.claude/settings.json` configuration file to define permissions and sandbox settings for Claude operations.

## Key Changes
- Created `.claude/settings.json` with the following configurations:
  - **Permissions**: Enabled `WebFetch` and `WebSearch` capabilities
  - **Sandbox Settings**: 
    - Enabled sandbox mode for security
    - Configured automatic bash allowance when sandboxed

## Implementation Details
The settings file establishes a baseline configuration that allows Claude to perform web-based operations (fetching and searching) while maintaining a sandboxed execution environment with automatic bash command authorization when the sandbox is active.

https://claude.ai/code/session_012Zf75Rf7DY5bKkLk6xCGFL