### PR TITLE
Enable experimental agent teams feature

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,5 +8,8 @@
   "sandbox": {
     "autoAllowBashIfSandboxed": true,
     "enabled": true
+  },
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   }
 }


### PR DESCRIPTION
## Summary
Enable the experimental agent teams feature by setting the `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` environment variable in the Claude settings configuration.

## Changes
- Added `env` configuration section to `.claude/settings.json`
- Set `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` environment variable to `"1"` to enable the experimental agent teams feature

## Details
This change activates an experimental feature that allows Claude to work with agent teams. The feature is controlled via an environment variable that can be toggled on or off by modifying the settings file.

https://claude.ai/code/session_01RBFLptvNX8ergveZpTT5wJ